### PR TITLE
Fix undefined method `start_with?' for /\.(?:svg|eot|otf|woff|ttf)$/

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,8 +32,6 @@ module PROJECT_NAME
 
     # Record the DB schema in SQL format for accuracy
     config.active_record.schema_format = :sql
-    config.assets.paths << Rails.root.join("app", "assets", "fonts")
-    config.assets.precompile << /\.(?:svg|eot|otf|woff|ttf)$/
 
     config.generators do |g|
       # Use UUID primary keys by default

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,6 +8,12 @@ Rails.application.config.assets.version = "1.0"
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
+Rails.application.config.assets.paths << Rails.root.join("app", "assets", "fonts")
+
+["svg", "eot", "otf", "woff", "ttf"].each do |extension|
+  Rails.application.config.assets.precompile << "*.#{extension}"
+end
+
 # Precompile additional assets.
 # application.js, application.scss, and all non-JS/CSS in the app/assets
 # folder are already added.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,7 +10,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 Rails.application.config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
-["svg", "eot", "otf", "woff", "ttf"].each do |extension|
+%w[svg eot otf woff ttf].each do |extension|
   Rails.application.config.assets.precompile << "*.#{extension}"
 end
 


### PR DESCRIPTION
Sprockets no longer support regex as a precompile option.

Ref: https://github.com/rails/sprockets/issues/632