### PR TITLE
Register headless chrome as a new Capybara driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
       2. [Configure the project](#configure-the-project)
       3. [Configure Code Climate](#configure-code-climate)
       4. [Configure CD](#configure-cd)
+      5. [Capybara drivers](#capybara-drivers)
    4. [Contributing](#contributing)
    5. [License](#license)
    6. [About Abtion](#about-abtion)
@@ -61,6 +62,13 @@ your own repository.
     - Staging: `<PROJECT-NAME>-staging`
     - Production: `<PROJECT-NAME>-production`
 3. Turn on "Review Apps" from the Pipeline's page
+
+### Capybara drivers
+
+This project registers two Capybara drivers.
+
+Set the environment variable `CAPYBARA_DRIVER` to `headless_chrome` (default) to run specs without
+opening Chrome, or use `chrome` to open the browser automatically.
 
 ## Contributing
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,8 +38,8 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.javascript_driver = ENV.fetch("TEST_DRIVER", "headless_chrome").to_sym
-Capybara.default_driver = ENV.fetch("TEST_DRIVER", "headless_chrome").to_sym
+Capybara.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
+Capybara.default_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,17 @@ Capybara.register_driver :chrome do |app|
   )
 end
 
-Capybara.javascript_driver = :chrome
-Capybara.default_driver = :chrome
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << "--headless"
+  browser_options.args << "--disable-gpu"
+  browser_options.args << "--window-size=1920,1080"
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.javascript_driver = ENV.fetch("TEST_DRIVER", "headless_chrome").to_sym
+Capybara.default_driver = ENV.fetch("TEST_DRIVER", "headless_chrome").to_sym
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Headless chrome is now the default. To use the previous driver, set:
TEST_DRIVER=chrome in .env.test

This PR does not cover extracting the capybara configuration into its own file, as mentioned on the Asana board by @GeoffAbtion.