### PR TITLE
Support DATABASE_URL in .env.local.

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -114,6 +114,7 @@ $ yarn install
 
 Prepare the database
 
+You can set `DATABASE_URL` in `.env.local`, if for instance you use Docker for Postgres. `DATABASE_URL="postgresql://localhost:5432"`
 ```sh
 $ bundle exec rails db:setup
 ```

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,14 +6,21 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
+local: &local
+  <<: *default
+  username: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).user : "" %>
+  password: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).password : "" %>
+  host: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).host : "" %>
+  port: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).port : "" %>
+
 # Development config
 development:
-  <<: *default
+  <<: *local
   database: PROJECT_NAME_development
 
 # Test config
 test:
-  <<: *default
+  <<: *local
   database: PROJECT_NAME_test
 
 # Staging/Production config


### PR DESCRIPTION
It doesn't set the database name from `DATABASE_URL`, so you can use the same url for both development and test.