### PR TITLE
Add basic structure for a JSON API with user authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "bootstrap", "~> 4.3.1"
 gem "cancancan"
 gem "devise"
-gem "jbuilder", "~> 2.5"
+gem "fast_jsonapi"
 gem "jquery-rails"
 gem "pg", ">= 0.18", "< 2.0"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,14 +111,14 @@ GEM
       railties (>= 4.2.0)
     faker (2.7.0)
       i18n (>= 1.6, < 1.8)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    jbuilder (2.9.1)
-      activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -293,7 +293,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  jbuilder (~> 2.5)
+  fast_jsonapi
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,7 +8,9 @@ module Api
       private
 
       def require_authentication!
-        user = User.find_by(authentication_token: request.headers["X-Api-Key"])
+        user = authenticate_or_request_with_http_token do |token, _options|
+          User.find_by(authentication_token: token)
+        end
 
         if user.present?
           sign_in user

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BaseController < ApplicationController
+      skip_before_action :verify_authenticity_token
+
+      private
+
+      def require_authentication!
+        user = User.find_by(authentication_token: request.headers["X-Api-Key"])
+
+        if user.present?
+          sign_in user
+        else
+          render status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersController < Api::V1::BaseController
+      before_action :require_authentication!
+
+      def show
+        render json: UserSerializer.new(current_user).serializable_hash
+      end
+    end
+  end
+end

--- a/app/models/concerns/api_authenticable.rb
+++ b/app/models/concerns/api_authenticable.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ApiAuthenticable
+  AUTHENTICATION_TOKEN_LENGTH = 64
+
+  extend ActiveSupport::Concern
+
+  included do
+    before_create do
+      self.authentication_token = generate_authentication_token
+    end
+
+    def generate_authentication_token
+      loop do
+        token = Devise.friendly_token(AUTHENTICATION_TOKEN_LENGTH)
+        break token unless self.class.find_by(authentication_token: token)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  include ApiAuthenticable
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   namespace :api, defaults: { format: :json } do
-    scope module: :v1, constraints: Constraints::ApiVersion.new("v1", true) do
+    scope module: :v1, constraints: Constraints::ApiVersion.new("v1") do
       resources :users, only: :show
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
+require "constraints/api_version"
+
 Rails.application.routes.draw do
   devise_for :users
+
+  namespace :api, defaults: { format: :json } do
+    scope module: :v1, constraints: Constraints::ApiVersion.new("v1", true) do
+      resources :users, only: :show
+    end
+  end
 
   root to: "home#index"
 end

--- a/db/migrate/20191126124825_add_authentication_token_to_users.rb
+++ b/db/migrate/20191126124825_add_authentication_token_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAuthenticationTokenToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :authentication_token, :string, index: true, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -62,7 +62,8 @@ CREATE TABLE public.users (
     reset_password_token character varying,
     reset_password_sent_at timestamp without time zone,
     remember_created_at timestamp without time zone,
-    admin boolean DEFAULT false
+    admin boolean DEFAULT false,
+    authentication_token character varying NOT NULL
 );
 
 
@@ -114,6 +115,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190521234616'),
 ('20190522002832'),
 ('20190522002904'),
-('20190522021338');
+('20190522021338'),
+('20191126124825');
 
 

--- a/lib/constraints/api_version.rb
+++ b/lib/constraints/api_version.rb
@@ -2,19 +2,15 @@
 
 module Constraints
   class ApiVersion
-    attr_reader :version, :default
+    attr_reader :version
 
-    def initialize(version, use_default = false)
+    def initialize(version)
       @version = version
-      @use_default = use_default
     end
 
     def matches?(request)
-      if request.headers["X-Api-Version"].present?
-        request.headers["X-Api-Version"] == @version
-      else
-        @use_default
-      end
+      request.headers["X-Api-Version"].present? &&
+        request.headers["X-Api-Version"] == version
     end
   end
 end

--- a/lib/constraints/api_version.rb
+++ b/lib/constraints/api_version.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Constraints
+  class ApiVersion
+    attr_reader :version, :default
+
+    def initialize(version, use_default = false)
+      @version = version
+      @use_default = use_default
+    end
+
+    def matches?(request)
+      if request.headers["X-Api-Version"].present?
+        request.headers["X-Api-Version"] == @version
+      else
+        @use_default
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::UsersController, type: :controller do
+  describe "#show" do
+    it "returns a 200 OK" do
+      user = FactoryBot.create(:user)
+      request.headers["X-Api-Key"] = user.authentication_token
+
+      get :show, params: { id: user.id }
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   describe "#show" do
     it "returns a 200 OK" do
       user = FactoryBot.create(:user)
-      request.headers["X-Api-Key"] = user.authentication_token
+      request.headers["Authorization"] = "Token #{user.authentication_token}"
 
       get :show, params: { id: user.id }
 

--- a/spec/models/concerns/api_authenticable_spec.rb
+++ b/spec/models/concerns/api_authenticable_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiAuthenticable, type: :model do
+  describe "before_create" do
+    it "sets an authentication_token automatically" do
+      user = build(:user, authentication_token: nil)
+      user.save
+
+      expect(user.authentication_token).to_not be_nil
+      expect(user.authentication_token.length).to eq(ApiAuthenticable::AUTHENTICATION_TOKEN_LENGTH)
+    end
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserSerializer, type: :serializer do
+  it "only exposes a subset of the user's data" do
+    user = FactoryBot.create(:user)
+
+    expect(described_class.new(user).serializable_hash).to eq(data: {
+                                                                attributes: {
+                                                                  name: user.name
+                                                                },
+                                                                id: user.id,
+                                                                type: :user
+                                                              })
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UserSerializer, type: :serializer do
   it "only exposes a subset of the user's data" do
-    user = FactoryBot.create(:user)
+    user = create(:user)
 
     expect(described_class.new(user).serializable_hash).to eq(data: {
                                                                 attributes: {


### PR DESCRIPTION
This commit sets a basic structure for a JSON API and handles:
* API versioning via a HTTP header
* User authentication via a HTTP header
* JSON serialization via fast_jsonapi

Shortcomings:
* To keep it as simple as possible, I opted for a single authentication token per user
* The token is not set to expire

I would like some feedback on this proposal, and would write documentation on API versioning and authentication if accepted.
I think this level is the right balance between being easily understandable by more junior developers, and setting a good foundation for more advanced developers.