### PR TITLE
Make project-specific strings easier to search-replace

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -167,15 +167,15 @@ By default, only admins are authorized to call a controller action.
 
 The project is hosted by [heroku](https://heroku.com).
 
-Current dyno types and add-on plans can be found in the project's [heroku dashboard](https://dashboard.heroku.com/apps/PROJECT_NAME-production). To access the dashboard, a heroku user with access to the abtion team is required.
+Current dyno types and add-on plans can be found in the project's [heroku dashboard](https://dashboard.heroku.com/apps/PROJECT_NAME_PARAM-production). To access the dashboard, a heroku user with access to the abtion team is required.
 
 ## Deployments
 
 Review apps and CI are enable for PR's. Auto merge setup to staging environment on merging of branches into master.
 
 Remote (App)
-Staging https://git.heroku.com/PROJECT_NAME-staging-eu.git (https://PROJECT_NAME-staging-eu.herokuapp.com/)
-Production https://git.heroku.com/PROJECT_NAME-production.git (https://PROJECT_NAME-production.herokuapp.com/)
+Staging https://git.heroku.com/PROJECT_NAME_PARAM-staging-eu.git (https://PROJECT_NAME_PARAM-staging-eu.herokuapp.com/)
+Production https://git.heroku.com/PROJECT_NAME_PARAM-production.git (https://PROJECT_NAME_PARAM-production.herokuapp.com/)
 
 # Staging
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ your own repository.
 
 1. Edit `application.rb` and change the module name and configuration settings.
 2. Edit the database names in `database.yml`
-3. Search the project for the word `PROJECT_NAME` to find other things to change.
+3. Use "search and replace" to replace project specific strings across all files:
+   - PROJECT_DOMAIN => project-name.com
+   - PROJECT_NAME_PARAM => project-name
+   - PROJECT_NAME_PASCAL => ProjectName
+   - PROJECT_NAME_SNAKE => project_name
+   - PROJECT_NAME_HUMAN => Project name
 4. `cp .env.example .env`
 5. `cp .env.development.example .env.development`
 6. `cp .env.test.example .env.test`

--- a/app.json
+++ b/app.json
@@ -47,10 +47,8 @@
       "required": true
     }
   },
-  "formation": {
-  },
-  "name": "PROJECT_NAME",
-  "scripts": {
-  },
+  "formation": {},
+  "name": "PROJECT_NAME_PARAM",
+  "scripts": {},
   "stack": "heroku-18"
 }

--- a/app/assets/stylesheets/globals/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/globals/_bootstrap_overrides.scss
@@ -1,10 +1,10 @@
 $theme-colors: (
-  "primary": $PROJECT_NAME-blue,
-  "secondary": $PROJECT_NAME-green,
-  "success": $PROJECT_NAME-green,
-  "info": $PROJECT_NAME-yellow,
-  "warning": $PROJECT_NAME-pink,
-  "dark": $PROJECT_NAME-darkblue
+  "primary": $PROJECT_NAME_PARAM-blue,
+  "secondary": $PROJECT_NAME_PARAM-green,
+  "success": $PROJECT_NAME_PARAM-green,
+  "info": $PROJECT_NAME_PARAM-yellow,
+  "warning": $PROJECT_NAME_PARAM-pink,
+  "dark": $PROJECT_NAME_PARAM-darkblue
 );
 
 $grid-breakpoints: (

--- a/app/assets/stylesheets/globals/_colors.scss
+++ b/app/assets/stylesheets/globals/_colors.scss
@@ -1,6 +1,6 @@
-$PROJECT_NAME-darkblue: #1e456a;
-$PROJECT_NAME-blue: rgb(0, 153, 255);
-$PROJECT_NAME-green: #4bbabb;
-$PROJECT_NAME-pink: rgb(255, 128, 128);
-$PROJECT_NAME-yellow: rgb(195, 162, 84);
+$PROJECT_NAME_PARAM-darkblue: #1e456a;
+$PROJECT_NAME_PARAM-blue: rgb(0, 153, 255);
+$PROJECT_NAME_PARAM-green: #4bbabb;
+$PROJECT_NAME_PARAM-pink: rgb(255, 128, 128);
+$PROJECT_NAME_PARAM-yellow: rgb(195, 162, 84);
 $grey: #999;

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
 
   <div>
     <%= f.label :email, class: 'visually-hidden' %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'user@PROJECT_NAME.com', tabindex: 1 %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'user@PROJECT_DOMAIN', tabindex: 1 %>
   </div>
 
   <div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
   <h3>Please log in</h3>
   <div>
     <%= f.label :email, class: 'visually-hidden' %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'user@PROJECT_NAME.com', class: 'form-control', tabindex: 1 %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'user@PROJECT_DOMAIN', class: 'form-control', tabindex: 1 %>
   </div>
 
   <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang='en-US'>
   <head>
-    <title>PROJECT_NAME</title>
+    <title>PROJECT_NAME_HUMAN</title>
     <meta charset='UTF-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-between">
-  <a class="navbar-brand" href="#">PROJECT_NAME</a>
+  <a class="navbar-brand" href="#">PROJECT_NAME_HUMAN</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module PROJECT_NAME
+module PROJECT_NAME_PASCAL
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: PROJECT_NAME_production
+  channel_prefix: PROJECT_NAME_SNAKE_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,12 +16,12 @@ local: &local
 # Development config
 development:
   <<: *local
-  database: PROJECT_NAME_development
+  database: PROJECT_NAME_SNAKE_development
 
 # Test config
 test:
   <<: *local
-  database: PROJECT_NAME_test
+  database: PROJECT_NAME_SNAKE_test
 
 # Staging/Production config
 production:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "PROJECT_NAME_production"
+  # config.active_job.queue_name_prefix = "PROJECT_NAME_SNAKE_production"
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "noreply-PROJECT_NAME@abtion.com"
+  config.mailer_sender = "noreply@PROJECT_DOMAIN"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.find_or_create_by(email: ENV.fetch("SEED_ADMIN_EMAIL", "admin@PROJECT_NAME.com")) do |u|
+User.find_or_create_by(email: ENV.fetch("SEED_ADMIN_EMAIL", "admin@PROJECT_DOMAIN")) do |u|
   password = ENV.fetch("SEED_ADMIN_INITIAL_PASSWORD", SecureRandom.hex(64))
 
   u.password = u.password_confirmation = password

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "PROJECT_NAME",
+  "name": "PROJECT_NAME_HUMAN",
   "private": true,
   "scripts": {
     "test": "echo 'No Node.js tests to run!'"


### PR DESCRIPTION
Makes it easier to use search-replace to update project-name strings across all files:
- PROJECT_DOMAIN => project-name.com
- PROJECT_NAME_PARAM => project-name
- PROJECT_NAME_PASCAL => ProjectName
- PROJECT_NAME_SNAKE => project_name
- PROJECT_NAME_HUMAN => Project name

Asana: https://app.asana.com/0/1142794766483633/1152060241410857

NB: I'm not sure how rails templates work, but I guess they have a built-in way to do something like this - in which case this might have to be migrated at some point