### PR TITLE
Suggestion: Removed seeds as part of test suite

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,8 +75,4 @@ RSpec.configure do |config|
   # Include integration helpers for feature tests
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::ControllerHelpers, type: :controller
-
-  config.before(:suite) do
-    Rails.application.load_seed # loading seeds
-  end
 end


### PR DESCRIPTION
I don't think we should automatically seed our database, in our test suite. If we need data to test we should only create it when needed, i think if we always seed this could result in some unexpected/unwanted behaviour when testing.

What are your thoughts on this? 😄 