### PR TITLE
Configured so ordering are using created_at

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,5 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  self.implicit_order_column = "created_at"
 end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationRecord, type: :model do
+  describe "uuid ordering" do
+    it "implicitly orders by created_at" do
+      expect(ApplicationRecord.implicit_order_column).to eq("created_at")
+    end
+  end
+end


### PR DESCRIPTION
When using UUID's, the active record methods 'first' and 'last' doesn't
work as expected, given that it's expecting an auto-incremented
id to sort by.