### PR TITLE
Disable rubocop check for application name case

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - "node_modules/**/*"
     - "bin/**/*"
+    - "vendor/**/*"
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ your own repository.
    - PROJECT_NAME_PASCAL => ProjectName
    - PROJECT_NAME_SNAKE => project_name
    - PROJECT_NAME_HUMAN => Project name
+
+   Note: The application name is wrapped around comments used to disable a rubocop check.
+   When the application has been renamed, the comments should be removed.
+   (See config/application.rb#L25-27)
 4. `cp .env.example .env`
 5. `cp .env.development.example .env.development`
 6. `cp .env.test.example .env.test`

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,9 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# rubocop:disable Naming/ClassAndModuleCamelCase
 module PROJECT_NAME_PASCAL
+  # rubocop:enable Naming/ClassAndModuleCamelCase
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0


### PR DESCRIPTION
Not the prettiest solution, but this should make rubocop pass.