### PR TITLE
Prevent timing attacks in API authentication

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -10,14 +10,18 @@ module Api
       def require_authentication!
         user = User.find(request.headers["X-User-Id"])
 
-        if user.present? && Devise.secure_compare(
-          "Token #{user.authentication_token}",
-          request.headers["Authorization"]
-        )
+        if user.present? && valid_token?(user.authentication_token)
           sign_in user
         else
           render status: :unauthorized
         end
+      end
+
+      def valid_token?(token)
+        ActiveSupport::SecurityUtils.secure_compare(
+          "Token #{token}",
+          request.headers["Authorization"]
+        )
       end
     end
   end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,11 +8,12 @@ module Api
       private
 
       def require_authentication!
-        user = authenticate_or_request_with_http_token do |token, _options|
-          User.find_by(authentication_token: token)
-        end
+        user = User.find(request.headers["X-User-Id"])
 
-        if user.present?
+        if user.present? && Devise.secure_compare(
+          "Token #{user.authentication_token}",
+          request.headers["Authorization"]
+        )
           sign_in user
         else
           render status: :unauthorized

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   describe "#show" do
     it "returns a 200 OK" do
       user = FactoryBot.create(:user)
+      request.headers["X-User-Id"] = user.id
       request.headers["Authorization"] = "Token #{user.authentication_token}"
 
       get :show, params: { id: user.id }


### PR DESCRIPTION
By first finding the user by its ID, and then comparing the
authentication tokens, we prevent timing attacks.
This solution however requires sending the user's ID alongside its
token.