### PR TITLE
Feature: Suppress puma log output for specs

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -13,6 +13,7 @@ Capybara.configure do |config|
 end
 
 Capybara.default_max_wait_time = 5
+Capybara.server = :puma, { Silent: true }
 
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
This stops pumas logs from messing with the dots.
No more:
```
Capybara starting Puma...
* Version 3.12.4 , codename: Llamas in Pajamas
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:9887
```