### PR TITLE
Feature: Extract code_coverage_helper into own file

### DIFF
--- a/spec/code_coverage_helper.rb
+++ b/spec/code_coverage_helper.rb
@@ -5,5 +5,6 @@ require "simplecov"
 unless ENV["DISABLE_SIMPLECOV"] == "true"
   SimpleCov.start("rails") do
     add_filter "spec"
+    add_filter "vendor"
   end
 end

--- a/spec/code_coverage_helper.rb
+++ b/spec/code_coverage_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+unless ENV["DISABLE_SIMPLECOV"] == "true"
+  SimpleCov.start("rails") do
+    add_filter "spec"
+  end
+end

--- a/spec/code_coverage_helper.rb
+++ b/spec/code_coverage_helper.rb
@@ -2,4 +2,9 @@
 
 require "simplecov"
 
-SimpleCov.start("rails") unless ENV["DISABLE_SIMPLECOV"] == "true"
+unless ENV["DISABLE_SIMPLECOV"] == "true"
+  SimpleCov.start("rails") do
+    add_filter "spec"
+    add_filter "vendor"
+  end
+end

--- a/spec/code_coverage_helper.rb
+++ b/spec/code_coverage_helper.rb
@@ -2,8 +2,4 @@
 
 require "simplecov"
 
-unless ENV["DISABLE_SIMPLECOV"] == "true"
-  SimpleCov.start("rails") do
-    add_filter "vendor"
-  end
-end
+SimpleCov.start("rails") unless ENV["DISABLE_SIMPLECOV"] == "true"

--- a/spec/code_coverage_helper.rb
+++ b/spec/code_coverage_helper.rb
@@ -4,7 +4,6 @@ require "simplecov"
 
 unless ENV["DISABLE_SIMPLECOV"] == "true"
   SimpleCov.start("rails") do
-    add_filter "spec"
     add_filter "vendor"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-require "simplecov"
-
-unless ENV["DISABLE_SIMPLECOV"] == "true"
-  SimpleCov.start "rails" do
-    add_filter "spec"
-  end
-end
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ Dotenv.load(
   ".env"
 )
 
+require "code_coverage_helper"
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Asana-tasks: [Extract code coverage helper file.](https://app.asana.com/0/1142794766483633/1156767475231026/f) & [Exclude /vendor from code coverage metrics](https://app.asana.com/0/1142794766483633/1156767475231022/f)
