### PR TITLE
Not needed in Rails 4 or newer

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,9 @@ plugins:
   # https://docs.codeclimate.com/docs/brakeman
   brakeman:
     enabled: true
+    checks:
+      no_attr_accessible:
+        enabled: false
 
   # https://docs.codeclimate.com/docs/bundler-audit
   bundler-audit:


### PR DESCRIPTION
In Rails 4 and newer, protection for mass assignment is on by default.