### PR TITLE
bin/setup: Create .env.development if it does not exist.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -25,6 +25,11 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
+  unless File.exist?(".env.development")
+    puts "\n== Creating .env.development from example file"
+    FileUtils.cp ".env.development.example", ".env.development"
+  end
+
   puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'
 


### PR DESCRIPTION
If the .env.development file does not exist, create it based on the
.env.development.example file.
If already exists, do nothing.

This allows an app to be setup from git clone to passing tests by a single: `bin/setup` command.