### PR TITLE
Remove STAGING_DATABASE_URL required env variable from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,9 +35,6 @@
   ],
   "buildpacks": [],
   "env": {
-    "STAGING_DATABASE_URL": {
-      "required": true
-    },
     "HEROKU_APP_NAME": {
       "required": true
     },


### PR DESCRIPTION
The `DATABASE_URL` is automatically set by Heroku, so if you really wish to use the staging database, you can alter the config vars on the indviduel review apps.