### PR TITLE
Replace CodeClimate's Brakeman and use Bundler instead

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,13 +6,6 @@ exclude_patterns:
   - public/**/*
 
 plugins:
-  # https://docs.codeclimate.com/docs/brakeman
-  brakeman:
-    enabled: true
-    checks:
-      no_attr_accessible:
-        enabled: false
-
   # https://docs.codeclimate.com/docs/bundler-audit
   bundler-audit:
     enabled: true

--- a/script/ci
+++ b/script/ci
@@ -16,5 +16,8 @@ bundle exec rubocop
 # run the ruby test suite
 bundle exec rake spec
 
+# run brakeman
+bundle exec brakeman
+
 # send report to code climate
 ./cc-test-reporter after-build --exit-code $?


### PR DESCRIPTION
We won't need to worry about having 2 different versions of brakeman running.