### PR TITLE
Set version of corejs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,6 +30,7 @@ module.exports = function(api) {
         {
           forceAllTransforms: true,
           useBuiltIns: 'entry',
+          corejs: 3,
           modules: false,
           exclude: ['transform-typeof-symbol']
         }


### PR DESCRIPTION
because of warning when precompiling assets and it is also the default in newly created rails 6 apps.