### PR TITLE
Add default_url_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ your own repository.
    When the application has been renamed, the comments should be removed.
    (See config/application.rb#L25-27)
 4. `mv README.example.md README.md`
-5. Set `MAIL_FROM` in your Heroku config vars (review, staging and production) or in `.env`.
 
 ### Configure Code Climate
 
@@ -71,6 +70,8 @@ your own repository.
     - Staging: `<PROJECT-NAME>-staging`
     - Production: `<PROJECT-NAME>-production`
 3. Turn on "Review Apps" from the Pipeline's page
+4. Set `MAIL_FROM` in your Heroku config vars (review, staging and production).
+5. Set `DOMAIN_NAME` in your Heroku config vars (staging and production), links in email will point to the provided domain name.
 
 ### Setup mailing
 

--- a/app.json
+++ b/app.json
@@ -38,6 +38,9 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
+    "MAIL_FROM": {
+      "required": true
+    },
     "SEED_ADMIN_EMAIL": {
       "required": true
     },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,10 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
+  hostname = ENV["DOMAIN_NAME"]
+  hostname ||= "#{ENV.fetch('HEROKU_APP_NAME')}.herokuapp.com"
+  config.action_mailer.default_url_options = { host: hostname }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: "localhost" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
The `HEROKU_APP_NAME` will automatically get set by review apps, but not by staging/production apps on Heroku.
There might be a cleaner way to go about this, suggestions are welcome!