### PR TITLE
Remove PROJECT_DOMAIN.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 SEED_ADMIN_EMAIL=admin@example.com
 SEED_ADMIN_INITIAL_PASSWORD=password
+MAIL_FROM=mail_from@example.com

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 SEED_ADMIN_EMAIL=admin@example.com
 SEED_ADMIN_INITIAL_PASSWORD=password
 CODE_COVERAGE_PERCENTAGE=100
+MAIL_FROM=mail_from@example.com

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ your own repository.
 1. Edit `application.rb` and change the module name and configuration settings.
 2. Edit the database names in `database.yml`
 3. Use "search and replace" to replace project specific strings across all files:
-   - PROJECT_DOMAIN => project-name.com
    - PROJECT_NAME_PARAM => project-name
    - PROJECT_NAME_PASCAL => ProjectName
    - PROJECT_NAME_SNAKE => project_name
@@ -55,6 +54,7 @@ your own repository.
    When the application has been renamed, the comments should be removed.
    (See config/application.rb#L25-27)
 4. `mv README.example.md README.md`
+5. Set `MAIL_FROM` in your Heroku config vars (review, staging and production) or in `.env`.
 
 ### Configure Code Climate
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
 
   <div>
     <%= f.label :email, class: 'visually-hidden' %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'user@PROJECT_DOMAIN', tabindex: 1 %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'user@example.com', tabindex: 1 %>
   </div>
 
   <div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
   <h3>Please log in</h3>
   <div>
     <%= f.label :email, class: 'visually-hidden' %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'user@PROJECT_DOMAIN', class: 'form-control', tabindex: 1 %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'user@example.com', class: 'form-control', tabindex: 1 %>
   </div>
 
   <div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,6 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     user_name: ENV["SENDGRID_USERNAME"],
     password: ENV["SENDGRID_PASSWORD"],
-    domain: "PROJECT_DOMAIN",
     address: "smtp.sendgrid.net",
     port: 587,
     authentication: :plain,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "noreply@PROJECT_DOMAIN"
+  config.mailer_sender = ENV.fetch("MAIL_FROM")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.find_or_create_by(email: ENV.fetch("SEED_ADMIN_EMAIL", "admin@PROJECT_DOMAIN")) do |u|
+User.find_or_create_by(email: ENV.fetch("SEED_ADMIN_EMAIL", "admin@example.com")) do |u|
   password = ENV.fetch("SEED_ADMIN_INITIAL_PASSWORD", SecureRandom.hex(64))
 
   u.password = u.password_confirmation = password


### PR DESCRIPTION
It is better to set it in an environment variable than save it in the repo.
It is still possible to save it in the repo, if wanted, by setting it in .env.
This way supports both wishes.

Also, it isn't necessary to specify domain for the smtp_settings.
From Rails mailer guide:
> :domain - If you need to specify a HELO domain, you can do it here.

The HELO domain might be added as a Received mail header. So if we add it, it should be a domain that identifies the webserver.
https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
> The information that the client sends in the HELO and MAIL FROM commands are added (not seen in example code) as additional header fields to the message by the receiving server. It adds a Received and Return-Path header field, respectively. 