### PR TITLE
Add mailing setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ your own repository.
     - Production: `<PROJECT-NAME>-production`
 3. Turn on "Review Apps" from the Pipeline's page
 
+### Setup mailing
+
+1. Go to the production app in the Heroku dashboard.
+2. Add Sendgrid addon.
+3. Click the added Sendgrid resource, go through the confirmation steps.
+4. Set up DKIM (under sender authentication -> domain authentication).
+5. Go to staging and repeat the above steps.
+6. If you want the review apps to send emails: Copy the staging app's Sendgrid credentials and add them to the review apps config vars. Do not add the Sendgrid addon to review apps in `app.json` (Sendgrid will ban our account).
+
 ### Capybara drivers
 
 This project registers two Capybara drivers.

--- a/app.json
+++ b/app.json
@@ -31,8 +31,7 @@
     }
   },
   "addons": [
-    "rollbar:free",
-    "sendgrid:starter"
+    "rollbar:free"
   ],
   "buildpacks": [],
   "env": {


### PR DESCRIPTION
Remove Sengrid from `app.json`, because we get banned by Sendgrid.