### PR TITLE
Configure CSP header.

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -1,5 +1,7 @@
 # Project Name Human
 
+![Observatory](https://img.shields.io/mozilla-observatory/grade-score/muffi-template.herokuapp.com)
+
 This project is built on top of [Muffi](https://github.com/abtion/muffi).
 
 1. [Project Name Human](#Project Name Human)
@@ -117,6 +119,7 @@ Inclusions:
   - FactoryBot
   - Capybara for acceptance testing
 - [Rollbar](https://rollbar.com) error monitoring
+- CSP header is configured, so if you need to use remotely hosted javascript, you must whitelist it in `config/initializers/content_security_policy.rb`
 
 Exclusions:
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,29 +1,33 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-# if Rails.env.development?
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035"
-# end
+Rails.application.config.content_security_policy do |policy|
+  policy.base_uri        :none
+  policy.default_src     :none
+  policy.font_src        :self, :https, :data
+  policy.form_action     :self
+  policy.frame_ancestors :none
+  policy.img_src         :self, :https, :data
+  policy.object_src      :none
+  policy.script_src      :self
+  policy.style_src       :self
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  if Rails.env.development?
+    policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035"
+  end
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  #   # Specify URI for violation reports
+  #   # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator =
-#   -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator =
+  ->(_request) { SecureRandom.base64(16) }
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
https://app.asana.com/0/1142794766483633/1188627776772511
https://observatory.mozilla.org/analyze/muffi-feature-csp-heade-gbvrsq.herokuapp.com

This should give 120/100 score on https://observatory.mozilla.org.
It will probably give some surprise, when trying to link to a script hosted remotely,
but some browsers give good error messages, explaining why the script isn't loaded.

For instance, if using Stripe Checkout. You need to change (Stripe's documentation on this is currently wrong):
```
  policy.frame_src   "https://js.stripe.com"
  policy.script_src  :self, "https://js.stripe.com"
```