### PR TITLE
app.json: Don't require HEROKU_APP_NAME env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
   ],
   "buildpacks": [],
   "env": {
-    "HEROKU_APP_NAME": {
-      "required": true
-    },
     "MAIL_FROM": {
       "required": true
     },


### PR DESCRIPTION
Slightly related to this:
https://app.asana.com/0/1142794766483633/1190999859256033

We only use HEROKU_APP_NAME in review apps, and it's set automatically for those.