### PR TITLE
Meta: Add action for auto-merging dependabot

### DIFF
--- a/.github/auto-merge-dependabot.yml
+++ b/.github/auto-merge-dependabot.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
We're using the [Dependabot Auto Merge](https://github.com/marketplace/actions/dependabot-auto-merge) action
from the Github Marketplace.
Also, we've added the `DEPENDABOT_TOKEN` as a secret for authorization.

We cannot trigger this action manually, so we're waiting for a security update to happen
to test it.

Associated task: https://app.asana.com/0/1142794766483633/1187208358171570/f

Co-authored-by: Mathias Jean Johansen <mj@abtion.com>
