### PR TITLE
Meta: Add details about Rubocop to README

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -99,6 +99,7 @@ Run: `bundle exec rspec`
 
 - Run the server: `heroku local` and [http://localhost:5000](http://localhost:5000)
 - Run tests: `bundle exec rspec`
+- Run rubocop: `bundle exec rubocop`
 
 ## Debugging
 
@@ -122,10 +123,11 @@ Inclusions:
 - Webpacker
 - Jest
 - PostgreSQL database (11.x)
+- [Rollbar](https://rollbar.com) error monitoring
 - RSpec runner
   - FactoryBot
   - Capybara for acceptance testing
-- [Rollbar](https://rollbar.com) error monitoring
+- Rubocop for linting ruby files
 - CSP header is configured, so if you need to use remotely hosted javascript, you must whitelist it in `config/initializers/content_security_policy.rb`
 - Sidekiq for running jobs
 


### PR DESCRIPTION
Adds missing details about Rubocop to README.example.

## Asana task
There is no Asana task for this.