### PR TITLE
Use SendGrid api token.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "pry"
 gem "puma", "~> 3.12"
 gem "rails", "6.0.3.4"
 gem "rollbar"
+gem "sendgrid-actionmailer"
 gem "sidekiq"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "webpacker", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,10 +243,16 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    ruby_http_client (3.5.1)
     rubyzip (2.0.0)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sendgrid-actionmailer (3.1.1)
+      mail (~> 2.7)
+      sendgrid-ruby (~> 6.0)
+    sendgrid-ruby (6.3.7)
+      ruby_http_client (~> 3.4)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
     sidekiq (6.1.2)
@@ -327,6 +333,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   selenium-webdriver
+  sendgrid-actionmailer
   shoulda-matchers
   sidekiq
   simplecov

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,17 +58,10 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.perform_deliveries = true
-
-  config.action_mailer.smtp_settings = {
-    user_name: ENV["SENDGRID_USERNAME"],
-    password: ENV["SENDGRID_PASSWORD"],
-    address: "smtp.sendgrid.net",
-    port: 587,
-    authentication: :plain,
-    enable_starttls_auto: true
+  config.action_mailer.delivery_method = :sendgrid_actionmailer
+  config.action_mailer.sendgrid_actionmailer_settings = {
+    api_key: ENV["SENDGRID_API_KEY"],
+    raise_delivery_errors: true
   }
 
   hostname = ENV["DOMAIN_NAME"]


### PR DESCRIPTION
Because username/password has been deprecated by SendGrid.