### PR TITLE
Simplify Capybara setup

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,19 +3,13 @@
 require "capybara/rspec"
 require "webdrivers/chromedriver" unless ENV.key?("DISABLE_WEBDRIVERS")
 
-Capybara.register_driver(:headless_chrome) do |app|
-  Capybara::Selenium::Driver.load_selenium
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << "--headless"
-  browser_options.args << "--disable-gpu"
-  browser_options.args << "--window-size=1920,1080"
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
-end
+# Default driver registrations
+# https://github.com/teamcapybara/capybara/blob/master/lib/capybara/registrations/drivers.rb
 
 Capybara.configure do |config|
   config.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
   config.default_max_wait_time = 5
   config.server = :puma, { Silent: true }
-  config.default_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
-  config.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
+  config.default_driver = ENV.fetch("CAPYBARA_DRIVER", "selenium_chrome_headless").to_sym
+  config.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "selenium_chrome_headless").to_sym
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,26 +3,6 @@
 require "capybara/rspec"
 require "webdrivers/chromedriver" unless ENV.key?("DISABLE_WEBDRIVERS")
 
-chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
-
-Selenium::WebDriver::Chrome.path = chrome_bin if chrome_bin
-chrome_opts = chrome_bin ? { "chromeOptions" => { "binary" => chrome_bin } } : {}
-
-Capybara.configure do |config|
-  config.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
-end
-
-Capybara.default_max_wait_time = 5
-Capybara.server = :puma, { Silent: true }
-
-Capybara.register_driver(:chrome) do |app|
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :chrome,
-    desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
-  )
-end
-
 Capybara.register_driver(:headless_chrome) do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
@@ -32,21 +12,10 @@ Capybara.register_driver(:headless_chrome) do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
-Capybara.default_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
-
-# This will fail feature specs on javascript errors/warnings
-RSpec.configure do |config|
-  config.after(:each, type: :feature) do
-    errors = page.driver.browser.manage.logs.get(:browser)
-
-    if errors.present?
-      aggregate_failures "javascript errors/warnings" do
-        errors.each do |error|
-          expect(error.level).not_to(eq("SEVERE"), error.message)
-          expect(error.level).not_to(eq("WARNING"), error.message)
-        end
-      end
-    end
-  end
+Capybara.configure do |config|
+  config.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
+  config.default_max_wait_time = 5
+  config.server = :puma, { Silent: true }
+  config.default_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
+  config.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym
 end

--- a/spec/support/javascript.rb
+++ b/spec/support/javascript.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#
+# This will fail feature specs on javascript errors/warnings
+RSpec.configure do |config|
+  config.after(:each, type: :feature) do
+    errors = page.driver.browser.manage.logs.get(:browser)
+
+    if errors.present?
+      aggregate_failures "javascript errors/warnings" do
+        errors.each do |error|
+          expect(error.level).not_to(eq("SEVERE"), error.message)
+          expect(error.level).not_to(eq("WARNING"), error.message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Keep only the headless chrome driver, as it is the one most developers
will use.

Move the javascript related support helper to its own file.

Co-authored-by: Martin Petersen <mp@abtion.com>

https://app.asana.com/0/1142794766483633/1199195024410608