### PR TITLE
Dependabot: Update all versions, not only security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Pull in new security threat patterns
+      - dependency-name: "brakeman"
+      # Pull in new linting patterns
+      - dependency-name: "scss-lint"
+      # Actually keep everything updated (if you remove this, keep the above ones).
+      - dependency-type: "all"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
By default Dependabot only creates pull requests for security updates.
With this configuration it will create pull requests for all updates daily.
The npm package caniuse-lite is updated daily (upstream), so to limit
the notifications, npm is configured to a weekly schedule.