### PR TITLE
Use rails server and port 3000 by default for dev

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -119,7 +119,7 @@ The hooks are symlinked meaning all the changes to the repo hooks will automatic
 
 ## Day-to-day
 
-- Run the server: `heroku local` and [http://localhost:5000](http://localhost:5000)
+- Run the server: `bin/rails server` and [http://localhost:3000](http://localhost:3000)
 - Run tests: `bundle exec rspec`
 - Run rubocop: `bundle exec rubocop`
 - Run prettier: `bin/prettier`

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ worker_timeout(3600) if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port(ENV.fetch("PORT", 5000))
+port(ENV.fetch("PORT", 3000))
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
I've changed the port to 3000 because that is most comment (as far as I know), and more importantly to make it match the port we've set for mailer urls in our development configuration.

```rb
  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
```

Asana: https://app.asana.com/0/1142794766483633/1200257919012205