### PR TITLE
No longer ignore omniauth cve

### DIFF
--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -27,7 +27,7 @@ unless Rails.env.production?
   end
 
   task bundle_audit: :environment do
-    sh "bundle exec bundle-audit --update --ignore CVE-2015-9284"
+    sh "bundle exec bundle-audit --update"
   end
 
   task yarn_lint: :environment do


### PR DESCRIPTION
We don't use omniauth on a lot of projects, and the newest version is not vulnerable

Asana: https://app.asana.com/0/1142794766483633/1200105395662329