### PR TITLE
Configure eslint to allowEscape.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     // enable additional rules
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "double"],
+    "quotes": ["error", "double", { "avoidEscape": true }],
     "quote-props": ["error", "consistent"],
 
     // Don't allow console.log


### PR DESCRIPTION
Prettier rewrites it to single quotes, when the strings contain double quotes.