### PR TITLE
Set nodejs version in package.json.

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,14 @@
     },
     "heroku-redis:hobby-dev"
   ],
-  "buildpacks": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ],
   "env": {
     "MAIL_FROM": {
       "required": true

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "popper.js": "^1.15.0",
     "webpack": "^4.0.0"
   },
+  "engines": {
+    "node": "14.x",
+    "yarn": "1.x"
+  },
   "version": "0.1.1",
   "devDependencies": {
     "eslint": "^7.28.0",


### PR DESCRIPTION
Add nodejs buildpack to get the an up to date node.js version (the one installed in the Ruby buildpack is currently v12.16.2)
https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack

https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
> You should always specify a Node.js version that matches the runtime you’re developing and testing with.
> Now, use the engines section of the package.json to specify the version of Node.js to use on Heroku.