### PR TITLE
 CI: Archive coverage reports on failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         run: bundle exec rspec
       - name: Archive coverage
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: coverage
           path: |


### PR DESCRIPTION
Since we require 100% covered, there is no reason to use time on archiving the reports unless it failed.