### PR TITLE
Also archive coverage reports on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         run: bundle exec rspec
       - name: Archive coverage
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: coverage
           path: |


### PR DESCRIPTION
If the failure is caused by too low coverage, then the report is important to have.