### PR TITLE
Ignore RoutingError in Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -33,6 +33,7 @@ Rollbar.configure do |config|
   #
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+  config.exception_level_filters["RoutingError"] = "ignore"
 
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)


### PR DESCRIPTION
Routing errors should always result in a 404, which we are handling with
a 404 page (it could be prettier), so this is not actually something we
want to be reported in Rollbar

For the future, I would think we would need a proper 404 page we can
reuse across all of our applications instead of rails standard page