### PR TITLE
Run `rails assets:precompile` instead of `webpack`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,39 @@ jobs:
           bundle exec rake db:migrate
       - name: check git diff
         run: git diff --exit-code db/schema.rb
+
+  assets-precompile:
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2.3.4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: install required apt packages
+        run: sudo apt-get -y install libpq-dev
+      - name: get yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Setup cache key and directory for node_modules cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: yarn
+        run: yarn --frozen-lockfile
+      - name: run bin/rails assets:precompile
+        run: bin/rails assets:precompile
+        
   rspec:
     runs-on: ubuntu-latest
 
@@ -206,8 +239,6 @@ jobs:
         run: |
           bundle exec rake db:create
           bundle exec rake db:schema:load
-      - name: run bin/webpack
-        run: bin/webpack
       - name: rspec
         env:
           # If we don't supply a CC_TEST_REPORTER_ID simplecov won't output coverage in a way that

--- a/yarn.lock
+++ b/yarn.lock
@@ -8367,9 +8367,9 @@ sass-loader@10.1.1:
     semver "^7.3.2"
 
 sass@^1.38.0:
-  version "1.41.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.41.1.tgz#bca5bed2154192779c29f48fca9c644c60c38d98"
-  integrity sha512-vIjX7izRxw3Wsiez7SX7D+j76v7tenfO18P59nonjr/nzCkZuoHuF7I/Fo0ZRZPKr88v29ivIdE9BqGDgQD/Nw==
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.39.0.tgz#6c64695d1c437767c8f1a4e471288e831f81d035"
+  integrity sha512-F4o+RhJkNOIG0b6QudYU8c78ZADKZjKDk5cyrf8XTKWfrgbtyVVXImFstJrc+1pkQDCggyidIOytq6gS4gCCZg==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
Because in some cases webpack will succeed where precompile will fail.
It is slower, but not slower than rspec, and now it is run in parallel.

https://app.asana.com/0/1142794766483633/1201016019690455