### PR TITLE
CI: Only run eslint in eslint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: yarn
         run: yarn --frozen-lockfile
       - name: lint
-        run: yarn lint
+        run: yarn eslint frontend
   stylelint:
     runs-on: ubuntu-latest
     steps:
@@ -193,7 +193,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: run bin/rails assets:precompile
         run: bin/rails assets:precompile
-        
+
   rspec:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
`yarn lint` runs prettier, eslint and stylelint.

Since we have other jobs in our CI for prettier and stylelint, it doesn't make sense that our eslint job runs them all.
Also, this change will make the output from the eslint job useful.