### PR TITLE
Configure Rails to comply with Spring 3.0.0

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
The default in Rails is `cache_classes = false`.
We think it was changed to true because of simplecov. Hopefully it works without problems now.

Co-authored-by: Markus Obelitz <mo@abtion.com>