### PR TITLE
Rename DATABASE_URL to DATABASE_SERVER.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      DATABASE_SERVER: postgres://postgres:postgres@localhost:5432
       RAILS_ENV: test
 
     services:

--- a/README.example.md
+++ b/README.example.md
@@ -69,9 +69,9 @@ Any env var you specify in such a file will override the configuration for the c
 
 #### Database connection
 
-You can set `DATABASE_URL` in `.env.local`, if you for instance use Docker for Postgres: `DATABASE_URL="postgresql://localhost:5432"`
+You can set `DATABASE_SERVER` in `.env.local`, if you for instance use Docker for Postgres: `DATABASE_SERVER="postgresql://localhost:5432"`
 Or if you just use a local postgres instance:
-`DATABASE_URL=postgresql://user:pass@localhost:5432`
+`DATABASE_SERVER=postgresql://user:pass@localhost:5432`
 
 ### 2. Dependencies and database setup
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,10 +8,10 @@ default: &default
 
 local: &local
   <<: *default
-  username: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).user : "" %>
-  password: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).password : "" %>
-  host: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).host : "" %>
-  port: <%= ENV.key?("DATABASE_URL") ? URI(ENV.fetch("DATABASE_URL")).port : "" %>
+  username: <%= ENV.key?("DATABASE_SERVER") ? URI(ENV.fetch("DATABASE_SERVER")).user : "" %>
+  password: <%= ENV.key?("DATABASE_SERVER") ? URI(ENV.fetch("DATABASE_SERVER")).password : "" %>
+  host: <%= ENV.key?("DATABASE_SERVER") ? URI(ENV.fetch("DATABASE_SERVER")).host : "" %>
+  port: <%= ENV.key?("DATABASE_SERVER") ? URI(ENV.fetch("DATABASE_SERVER")).port : "" %>
 
 # Development config
 development:


### PR DESCRIPTION
Because Rails behaves differently when DATABASE_URL is used.
https://github.com/rails/rails/blob/a81aeb63a007ede2fe606c50539417dada9030c7/activerecord/lib/active_record/railties/databases.rake#L43
> it defaults to creating the development and test databases, except when DATABASE_URL is present.