### PR TITLE
Default capybara browser size

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -19,6 +19,9 @@ This project is built on top of [Muffi](https://github.com/abtion/muffi).
    - [Day-to-day](#day-to-day)
    - [Debugging](#debugging)
    - [Download production or staging DB](#download-production-or-staging-db)
+   - [System specs (E2E tests)](#system-specs-e2e-tests)
+     - [Switching browser driver](#switching-browser-driver)
+     - [Screenshots in CI](#screenshots-in-ci)
 4. [Notable inclusions and Notable exclusions](#notable-inclusions-and-notable-exclusions)
    1. [Devise User Authorization](#devise-user-authorization)
 5. [Production](#production)
@@ -171,6 +174,33 @@ It contains personal data, and the environment you download it to must be as sec
 Additionally, you must ensure that the data is deleted afterwards.
 
 If for some reason you need to download production data anyway, you can use [parity](https://github.com/thoughtbot/parity).
+
+## System specs (E2E tests)
+
+We use [rspecs adaptor for rails system test](https://relishapp.com/rspec/rspec-rails/v/5-1/docs/system-specs/system-spec), which in turn is using [capybara](https://github.com/teamcapybara/capybara).
+
+The configuration is kept in `spec/support/capybara.rb`.
+
+### Switching browser driver
+
+By default the systems specs are executed in a headless chrome browser.
+
+To see what's going on in a spec use the `CAPYBARA_DRIVER` env var to set a non-headless browser, e.g.:
+
+`CAPYBARA_DRIVER=chrome bundle exec rspec`
+
+Available options are (as per possible names [here](https://github.com/rails/rails/blob/df1e1bc35c6210ecb39532a06823a6cf4f07bcd8/actionpack/lib/action_dispatch/system_testing/browser.rb)):
+
+- `chrome`
+- `firefox`\*
+- `headless_chrome`
+- `headless_firefox`\*
+
+\* Firefox options are untested and therefore cannot be relied upon
+
+### Screenshots in CI
+
+When system spec fails in CI a screenshot will be saved as a Github Actions artifact. If need be you can download the `capybara.zip` file and extract it to get to the screenshots.
 
 # Notable inclusions and Notable exclusions
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@
       6. [Configure i18n tasks](#configure-i18n-tasks)
       7. [Setup mailing](#setup-mailing)
       8. [Setup basic auth](#setup-basic-auth)
-      9. [Capybara drivers](#capybara-drivers)
-      10. [Capybara Screenshots in CI](#capybara-screenshots-in-ci)
-      11. [Set up Dependabot](#set-up-dependabot)
-      12. [Set up database backups](#set-up-database-backups)
+      9. [Set up Dependabot](#set-up-dependabot)
+      10. [Set up database backups](#set-up-database-backups)
    4. [Contributing](#contributing)
    5. [License](#license)
    6. [About Abtion](#about-abtion)
@@ -181,17 +179,6 @@ For added security we want to add basic auth to our review/staging environments.
 2. Add environment variables for:
 3. `HTTP_AUTH_USERNAME`
 4. `HTTP_AUTH_PASSWORD`
-
-### Capybara drivers
-
-This project registers two Capybara drivers.
-
-Set the environment variable `CAPYBARA_DRIVER` to `headless_chrome` (default) to run specs without
-opening Chrome, or use `chrome` to open the browser automatically.
-
-### Capybara Screenshots in CI
-
-When a spec using Capybara fails in CI a screenshot will be saved under Github Actions Artifacts. If need be you can download the `capybara.zip` file and extract it to get to the screenshots.
 
 ### Set up Dependabot
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -18,5 +18,6 @@ end
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by(ENV.fetch("CAPYBARA_DRIVER", "selenium_chrome_headless").to_sym)
+    page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -17,7 +17,7 @@ end
 # So we set it the rails way instead of the capybara way
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by(ENV.fetch("CAPYBARA_DRIVER", "selenium_chrome_headless").to_sym)
-    page.driver.browser.manage.window.resize_to(1920, 1080)
+    driven_by(:selenium, using: ENV.fetch("CAPYBARA_DRIVER", "headless_chrome").to_sym,
+                         screen_size: [1920, 1080])
   end
 end


### PR DESCRIPTION
Since we removed configs for the default size of browser [here](https://github.com/abtion/muffi/commit/1dd08422c754b7c7a4339f2a9817b3f679d3daea#diff-d522976f73ce246aff733a18173712d72bb311e61561ea37eb1ee0d04b78fe9aL31 ) 
It is causing some issues when updating capybara configs in other projects