### PR TITLE
Run only rspec tests with coverage on CI as part of the rspec job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           bin/rake db:create
           bin/rake db:schema:load
       - name: rspec
-        run: bin/rspec
+        run: bin/rspec-coverage
       - name: Archive capybara artifacts
         uses: actions/upload-artifact@v3
         if: failure()

--- a/bin/rspec-coverage
+++ b/bin/rspec-coverage
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+CODE_COVERAGE_PERCENTAGE=100 bin/rspec

--- a/bin/test-coverage
+++ b/bin/test-coverage
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 set -e
 
-CODE_COVERAGE_PERCENTAGE=100 bin/rspec
+bin/rspec-coverage
 yarn test --coverage


### PR DESCRIPTION
Previously the bin/test-coverage script was called, but this includes
running the JS tests with coverage enabled which duplicates work
already done by the jest job.

Note: care was taken to keep coverage percentage defined only once