### PR TITLE
CI: Remove insecure db trust auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5


### PR DESCRIPTION
Postgres docs says:
>          You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
 >         connections without a password. This is *not* recommended.