### PR TITLE
CI: Update postgres to 14.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:14.6
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
This is the default version used on Heroku currently