### PR TITLE
chore: bump Ruby 3.3.9 → 3.4.9

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.9
+ruby 3.4.9
 nodejs 24.14.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,7 +515,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.3.9p170
+   ruby 3.4.9p82
 
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION
Bumps Ruby from 3.3.9 to 3.4.9 (recommended version per [FastRuby compatibility table](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html) for Rails 8.1).

### Changes
- `.tool-versions`: ruby 3.3.9 → 3.4.9
- `Gemfile.lock`: updated RUBY VERSION

[Ruby 3.4.9 release notes](https://www.ruby-lang.org/en/news/2026/03/11/ruby-3-4-9-released/)