### PR TITLE
Bump postcss 8.4.47 → 8.5.13 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "markdownlint-cli2": "^0.21.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.5.13",
         "prettier": "^3.6.0",
         "stylelint": "^16.23.1",
         "stylelint-config-sass-guidelines": "^12.1.0",
@@ -73,7 +73,7 @@
         "npm": ">=11.10.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.33"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/@abtion-oss/design-system-colors": {
@@ -11600,9 +11600,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",
@@ -11617,9 +11617,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,16 +71,16 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "markdownlint-cli2": "^0.21.0",
-    "postcss": "^8.4.33",
+    "postcss": "^8.5.13",
     "prettier": "^3.6.0",
     "stylelint": "^16.23.1",
     "stylelint-config-sass-guidelines": "^12.1.0",
     "webpack-dev-server": "^5.2.3"
   },
   "peerDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.5.13"
   },
   "overrides": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.5.13"
   }
 }


### PR DESCRIPTION
Fixes XSS via unescaped `</style>` in CSS stringify output.

Updated devDependencies, peerDependencies, and overrides to `^8.5.13`.

Advisory: https://github.com/advisories/GHSA-qx2v-qp2m-jg93