### PR TITLE
Add env-var interpolation to docker-compose ports

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 REDIS_URL=redis://localhost:6379
 DATABASE_SERVER="postgresql://postgres@localhost:5432"
+POSTGRES_PORT=5432
+REDIS_PORT=6379
 SEED_ADMIN_EMAIL=admin@example.com
 SEED_ADMIN_INITIAL_PASSWORD=password
 SIDEKIQ_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ token to the settings of your project on GitHub. Follow these steps:
 
 To enable DB backups, see this guide: <https://github.com/abtion/heroku-db-backup-s3>
 
+### Custom Docker Ports
+
+Docker services bind to default ports (Postgres 5432, Redis 6379). To use custom host ports (e.g. to run multiple projects simultaneously), set `POSTGRES_PORT` and/or `REDIS_PORT` in `.env.local` and make sure they're exported before running `docker compose`.
+
 ## Contributing
 
 The Abtion Rails Template is maintained by [_Abtioneers_](#about-abtion), but open for anyone to suggest improvements and bugfixes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: postgres:15.5-alpine
     ports:
-      - 127.0.0.1:5432:5432
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
@@ -10,7 +10,7 @@ services:
   redis:
     image: redis:6-alpine
     ports:
-      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
 
   # Optional containers for development
   install-deps:


### PR DESCRIPTION
Allow unique host ports via `POSTGRES_PORT`/`REDIS_PORT` env vars with 5432/6379 defaults so multiple projects can run simultaneously.

### Changes

- **docker-compose.yml**: Replace hardcoded port mappings with `${POSTGRES_PORT:-5432}:5432` and `${REDIS_PORT:-6379}:6379`
- **.env**: Add `POSTGRES_PORT=5432` and `REDIS_PORT=6379` defaults
- **README.md**: Add "Custom Docker Ports" section explaining how to use custom ports

### Impact

Zero impact for existing developers — defaults are unchanged. Developers who want to run multiple projects simultaneously can set custom ports in `.env.local` (gitignored).