### PR TITLE
Pin npm engine range to prevent unintended npm 12 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       },
       "engines": {
         "node": ">=24.14.1",
-        "npm": ">=11.10.0"
+        "npm": "^11.10.0"
       },
       "peerDependencies": {
         "postcss": "^8.5.13"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "packageManager": "npm@11.10.0",
   "engines": {
     "node": ">=24.14.1",
-    "npm": ">=11.10.0"
+    "npm": "^11.10.0"
   },
   "version": "0.1.1",
   "browserslist": [


### PR DESCRIPTION
npm 12 has just been released and Heroku's Node buildpack is not confirmed to handle it yet. This project's `engines.npm` was an unbounded `>=11.10.0` range, which would silently allow npm 12 to be resolved during a build even though the `packageManager` corepack pin already guards against it.

Changes:
- Tighten `engines.npm` to a caret range `^11.10.0` (excludes npm 12 until deliberately bumped), matching the existing `packageManager` pin

No dependency or behavior changes — purely bounding the npm version range to what's already installed.